### PR TITLE
Solve broken stackoverflow profile link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -104,7 +104,7 @@ author:
   linkedin         : "https://linkedin.com/in/simandebvu"
   pinterest        :
   soundcloud       :
-  stackoverflow    : "https://stackoverflow.com/users/3630502/the-gentleman"
+  stackoverflow    : "3630502/the-gentleman"
   steam            :
   tumblr           :
   twitter          : "simandebvu"


### PR DESCRIPTION
Hi Shingirayi,

Just a small PR to solve broken **Stackoverflow** profile link.

Wrong URL:
https://www.stackoverflow.com/users/https://stackoverflow.com/users/3630502/the-gentleman

Correct page:
https://stackoverflow.com/users/3630502/the-gentleman

Regards,